### PR TITLE
fix hidden symbols in robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -14,7 +14,7 @@ User-agent: Applebot-Extended
 User-agent: Bytespider
 User-agent: CCBot
 User-agent: ChatGPT-User
-‍User-agent: Claude-Web
+User-agent: Claude-Web
 User-agent: ClaudeBot
 User-agent: cohere-ai
 User-agent: Diffbot


### PR DESCRIPTION
в строку попали левые символы (od -c robots.txt)
<img width="804" alt="Screenshot 2025-03-24 at 20 42 30" src="https://github.com/user-attachments/assets/6c8bf40a-f25e-4a2d-9e94-074846d630ef" />

поэтому robots.txt невалидный
<img width="423" alt="Screenshot 2025-03-24 at 20 23 41" src="https://github.com/user-attachments/assets/1940c0e9-1b44-4495-b520-b4ac926373fb" />
